### PR TITLE
additional support for file path rewrite 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,8 +35,8 @@ See - [Veracode pipeline scan example in github action](https://help.veracode.co
   with:
     pipeline-results-json: results.json
     output-results-sarif: veracode-results.sarif
-    source-base-path-1: "^com\/veracode:src\/main\/java\/com\/veracode"
-    source-base-path-2: "^WEB-INF:src\/main\/webapp\/WEB-INF"
+    source-base-path-1: "^com/veracode:src/main/java/com/veracode"
+    source-base-path-2: "^WEB-INF:src/main/webapp/WEB-INF"
     
     
 - name: upload sarif file to repository

--- a/Readme.md
+++ b/Readme.md
@@ -12,33 +12,53 @@ See - [Veracode pipeline scan example in github action](https://help.veracode.co
 
 <hr>
 
-## Inputs
+# Inputs
 
-### `pipeline-results-json`
+## `pipeline-results-json`
 
-**Required** The path to the pipeline json result file. Default `"results.json"`.
+**Required** The path to the pipeline json result file. 
+|Default value |  `"results.json"`|
+--- | ---
 
-### `output-results-sarif`
+## `output-results-sarif`
 
-**Optional** The path to the SARIF format result file. Default `"veracode-results.sarif"`.
+**Optional** The path to the SARIF format result file.
+|Default value|`"veracode-results.sarif"`|
+--- | ---
 
-### `source-base-path-1` (can go from `1` to `3`)
+## `source-base-path-1` (can go from `1` to `3`)
 
-**Optional** In some compilations, the path representation is not the same as the repository root folder. In order to add the ability to navigate back from the scanning issue to the file in the repository, a base path to the source is required. The input format is regex base (`"[search pattern]:[replace with pattern]"`). Defalue `""`.
+**Optional** In some compilations, the path representation is not the same as the repository root folder. In order to add the ability to navigate back from the scanning issue to the file in the repository, a base path to the source is required. The input format is regex base (`"[search pattern]:[replace with pattern]"`). 
+| Default value | `""` |
+--- | ---
 
-## Example usage
+## `finding-rule-level`
+
+**Optional** The conversion rule from Veracode finding levels to Github levels.
+
+- **Veracode levels**: 5 = `Very High`, 4 = `High`, 3 = `Medium`, 2 = `Low`, 1 = `Very Low`, 0 = `informational`.
+- **GitHub levels**: `error`, `warning`, `note`.  
+
+Example values: 
+- "4:3:0" => `High` and `Very high` will show as `error`, Medium as `warning` and the rest as `note`
+- "3:2:1" => `Medium` and above will show as `error`, `Low` as `warning`, `Very Low` as `note`, and `informational` will not show at all
+
+**Note:**  Only **`error`** level will fail pull request check 
+| Default value| `"4:3:0"` |
+--- | ---
+# Example usage
 
 ```
 - name: Convert pipeline scan output to SARIF format
   id: convert   
-  uses: Lerer/veracode-pipeline-scan-results-to-sarif@v1.0.4
+  uses: Lerer/veracode-pipeline-scan-results-to-sarif@v1.0.5
   with:
     pipeline-results-json: results.json
     output-results-sarif: veracode-results.sarif
     source-base-path-1: "^com/veracode:src/main/java/com/veracode"
     source-base-path-2: "^WEB-INF:src/main/webapp/WEB-INF"
-    
-    
+    finding-rule-level: "3:1:0"
+      
 - name: upload sarif file to repository
   uses: github/codeql-action/upload-sarif@v1
   with: # Path to SARIF file relative to the root of the repository

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'a path prefix conversion before publish in the SARIF file'
     required: false
     default: ''
+  finding-rule-level:
+    description: 'The conversion rule of Veracode findings to GitHub level'
+    required: true
+    default: '4:3:0'
 runs:
   using: 'node12'
   main: 'convert-action.js'

--- a/convert-action.js
+++ b/convert-action.js
@@ -72,7 +72,11 @@ const addRuleToRules = (issue,rules) => {
         },
         helpUri: "https://cwe.mitre.org/data/definitions/"+issue.CWEId+".html",
         properties: {
-            category: issue.IssueTypeId
+            category: issue.IssueTypeId,
+            tags: [issue.IssueTypeId]
+        },
+        defaultConfiguration: {
+            level: sevIntToStr(issue.Severity)
         }
     }
 

--- a/convert-action.js
+++ b/convert-action.js
@@ -44,9 +44,6 @@ const addRuleToRules = (issue,rules) => {
         helpUri: "https://cwe.mitre.org/data/definitions/"+issue.CWEId+".html",
         properties: {
             category: issue.IssueTypeId
-        },
-        messageStrings: {
-            default: issue.IssueType 
         }
     }
 
@@ -129,8 +126,7 @@ const convertPipelineResultFileToSarifFile = (inputFileName,outputFileName) => {
                     text: issue.Title + ' - '+issue.DisplayText,
                 },
                 locations: [location],
-                ruleId: issue.CWEId,
-                ruleMessageId: "default"
+                ruleId: issue.CWEId
             }
             return resultItem;
         })

--- a/convert-action.js
+++ b/convert-action.js
@@ -225,6 +225,7 @@ const convertPipelineResultFileToSarifFile = (inputFileName,outputFileName) => {
 }
 
 try {
+    sliceReportLevels(reportLevels);
     setupSourceReplacement(srcBasePath1,srcBasePath2,srcBasePath3);
     convertPipelineResultFileToSarifFile(pipelineInputFileName,sarifOutputFileName);
 } catch (error) {

--- a/convert-action.js
+++ b/convert-action.js
@@ -123,7 +123,7 @@ const convertPipelineResultFileToSarifFile = (inputFileName,outputFileName) => {
             let resultItem = {
                 level: serStr,
                 message: {
-                    text: issue.Title + ' - '+issue.DisplayText,
+                    text: issue.DisplayText,
                 },
                 locations: [location],
                 ruleId: issue.CWEId

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,5 +1,5 @@
 
-const { convertToSarif,setupSourceReplacement } = require('../convert-action');
+const { convertToSarif,setupSourceReplacement,sliceReportLevels } = require('../convert-action');
 
 const DEFAULT_INPUT_FILE = 'results.json';
 const DEFAULT_OUTPUT_FILE = 'veracode-results.sarif';
@@ -18,7 +18,11 @@ if (args.length>=4) {
     outputFileName = args[3];
 } 
 
-try {
+try { 
+    sliceReportLevels('4:1:0');
+    sliceReportLevels('3:0:0');
+    sliceReportLevels('4:3:0');
+    sliceReportLevels('3:1:0');
     setupSourceReplacement(sub1,sub2);
     convertToSarif(inputFileName,outputFileName);
 } catch (error) {


### PR DESCRIPTION
When a code is compiled, it may loss its location relatively to its place in the source repository. As a result relying directly on the scan result to get the source code path is incorrect. This latest update allow to override the source code file path by providing a match regex for and a replace value on the file path.

See documentation and example in the parent repository 