### PR TITLE
Fix CLI argument parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,39 @@
 #!/usr/bin/env node
 
-import program from 'commander'
-import {run} from "./index";
+import { program, Option } from 'commander'
+import { run } from "./index";
 
 program
     .version('0.0.1')
     .requiredOption('-i, --input <path>', 'Input file to convert')
     .requiredOption('-o, --output <path>', 'Output file to convert')
+    .addOption(new Option('-s, --scan-type <string>', 'Scan type').default('pipeline').choices(['pipeline', 'policy']))
     .option('-r, --rule-level <string>', 'Rule level', '4:3:0')
     .option('-p, --path-replace <string>', 'Path replacements', '')
+    .option('--repo-owner <string>', 'Repository owner')
+    .option('--repo-name <string>', 'Repository name')
+    .option('-g, --github-token <string>', 'GitHub tokens')
+    .option('-c, --commit-sha <string>', 'Commit SHA')
+    .option('-R, --ref <string>', 'Ref')
+    .option('-n, --noupload', 'Don\'t upload results to GitHub', false)
     .parse(process.argv)
 
 try {
     let opts = program.opts()
     run({
-        scanType: opts["pathReplace"],
+        scanType: opts["scanType"],
+        // inputFilename is used for pipeline scans, resultsJson otherwise (see index.ts)
         resultsJson: opts["input"],
         inputFilename: opts["input"],
         outputFilename: opts["output"],
         ruleLevel: opts["ruleLevel"],
         pathReplacers: opts["pathReplace"],
-        repo_owner: opts["pathReplace"],
-        repo_name: opts["pathReplace"],
-        githubToken: opts["pathReplace"],
-        commitSHA: opts["pathReplace"],
-        ref: opts["pathReplace"],
-        noupload: opts["pathReplace"]
+        repo_owner: opts["repoOwner"],
+        repo_name: opts["repoName"],
+        githubToken: opts["githubToken"],
+        commitSHA: opts["commitSHA"],
+        ref: opts["ref"],
+        noupload: opts["noupload"].toString()
     }, msg => console.log(msg))
 } catch (error) {
     console.error(error.message);


### PR DESCRIPTION
This interface was never really functional—this should be better now. This PR doesn't include a rebuild `dist/index.ts` to avoid noise in the changes.