### PR TITLE
Fixes Update SARIF JSON schema location #42

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28950,7 +28950,7 @@ class Converter {
             .map(issue => this.issueToResult(issue));
         // construct the full SARIF content
         return {
-            $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            $schema: "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             version: "2.1.0",
             runs: [
                 {
@@ -29154,7 +29154,7 @@ class Converter {
             .map(findings => this.findingToResult(findings));
         // construct the full SARIF content
         return {
-            $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            $schema: "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             version: "2.1.0",
             runs: [
                 {

--- a/src/Converter.ts
+++ b/src/Converter.ts
@@ -47,7 +47,7 @@ export class Converter {
 
         // construct the full SARIF content
         return {
-            $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            $schema: "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             version: "2.1.0",
             runs: [
                 {
@@ -262,7 +262,7 @@ export class Converter {
 
         // construct the full SARIF content
         return {
-            $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            $schema: "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             version: "2.1.0",
             runs: [
                 {

--- a/test_resource/policy_flaws.sarif.json
+++ b/test_resource/policy_flaws.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/test_resource/resultsToSarif.sarif.json
+++ b/test_resource/resultsToSarif.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/test_resource/sarifToResults.sarif.json
+++ b/test_resource/sarifToResults.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {


### PR DESCRIPTION
Replace schema location throughout with the one hosted at https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json